### PR TITLE
fix: make log dir in test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ clean:
 
 test:
 	cp /tmp/minitwit.db /tmp/minitwit_test.db
+	mkdir -p log
 	APP_ENV=test nohup bundle exec ruby myapp.rb > ./log/test.log 2>&1 &
 	sleep 2
 	- pytest refactored_minitwit_tests.py -vvv


### PR DESCRIPTION
mkdir with -p flag does not error if already exists so this action is idempotent