### PR TITLE
CICD pipeline

### DIFF
--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -10,14 +10,6 @@ on:
   workflow_dispatch:
     manual: true
 
-# Remember to set the following secrets in your repository's settings:
-# https://github.com/your_username/itu-minitwit-ci/settings/secrets/actions
-# DOCKER_USERNAME
-# DOCKER_PASSWORD
-# SSH_USER
-# SSH_KEY
-# SSH_HOST
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -44,34 +36,6 @@ jobs:
           tags: ${{ secrets.DOCKER_USERNAME }}/minitwit:latest
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwit:webbuildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwit:webbuildcache,mode=max
-
-      #  - name: Build and push mysqlimage
-      #    uses: docker/build-push-action@v2
-      #    with:
-      #      context: .
-      #      file: ./Dockerfile-mysql
-      #      push: true
-      #      tags: ${{ secrets.DOCKER_USERNAME }}/mysqlimage:latest
-      #      cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/mysqlimage:mysqlbuildcache
-      #      cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/mysqlimage:mysqlbuildcache,mode=max
-
-      # - name: Build and push flagtoolimage
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     context: .
-      #     file: ./Dockerfile-flagtool
-      #     push: true
-      #     tags: ${{ secrets.DOCKER_USERNAME }}/flagtoolimage:latest
-      #     cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/flagtoolimage:flagtoolbuildcache
-      #     cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/flagtoolimage:flagtoolbuildcache,mode=max
-
-      # - name: Test minitwit
-      #   run: |
-      #     docker build -t $DOCKER_USERNAME/minitwittestimage -f Dockerfile-minitwit-tests .
-      #     yes 2>/dev/null | docker-compose up -d
-      #     docker run --rm --network=itu-minitwit-network $DOCKER_USERNAME/minitwittestimage
-      #   env:
-      #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 
       - name: Configure SSH
         run: |

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -77,8 +77,10 @@ jobs:
 
       - name: Configure SSH
         run: |
+          sudo apt install -y dos2unix
           mkdir -p ~/.ssh/
           echo "$SSH_KEY" > ~/.ssh/do_ssh_key
+          dos2unix ~/.ssh/do_ssh_key
           chmod 400 ~/.ssh/do_ssh_key
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -47,15 +47,15 @@ jobs:
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwit:webbuildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwit:webbuildcache,mode=max
 
-    #  - name: Build and push mysqlimage
-    #    uses: docker/build-push-action@v2
-    #    with:
-    #      context: .
-    #      file: ./Dockerfile-mysql
-    #      push: true
-    #      tags: ${{ secrets.DOCKER_USERNAME }}/mysqlimage:latest
-    #      cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/mysqlimage:mysqlbuildcache
-    #      cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/mysqlimage:mysqlbuildcache,mode=max
+      #  - name: Build and push mysqlimage
+      #    uses: docker/build-push-action@v2
+      #    with:
+      #      context: .
+      #      file: ./Dockerfile-mysql
+      #      push: true
+      #      tags: ${{ secrets.DOCKER_USERNAME }}/mysqlimage:latest
+      #      cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/mysqlimage:mysqlbuildcache
+      #      cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/mysqlimage:mysqlbuildcache,mode=max
 
       # - name: Build and push flagtoolimage
       #   uses: docker/build-push-action@v2
@@ -78,7 +78,7 @@ jobs:
       - name: Configure SSH
         run: |
           mkdir -p ~/.ssh/
-          echo "$SSH_KEY" > ~/.ssh/do_ssh_key
+          echo -n "$SSH_KEY" > ~/.ssh/do_ssh_key
           chmod 600 ~/.ssh/do_ssh_key
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -78,8 +78,8 @@ jobs:
       - name: Configure SSH
         run: |
           mkdir -p ~/.ssh/
-          echo -n "$SSH_KEY" > ~/.ssh/do_ssh_key
-          chmod 600 ~/.ssh/do_ssh_key
+          echo "$SSH_KEY" > ~/.ssh/do_ssh_key
+          chmod 400 ~/.ssh/do_ssh_key
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
 

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -77,13 +77,9 @@ jobs:
 
       - name: Configure SSH
         run: |
-          command -v ssh-agent >/dev/null || ( apt-get update -y && apt-get install openssh-client -y )
-          eval $(ssh-agent -s)
-          echo "$SSH_KEY" | tr -d '\r' | ssh-add -
-          mkdir -p ~/.ssh
-          touch ~/.ssh/config
-          touch ~/.ssh/known_hosts
-          chmod -R 400 ~/.ssh
+          mkdir -p ~/.ssh/
+          echo "$SSH_KEY" > ~/.ssh/do_ssh_key
+          chmod 600 ~/.ssh/do_ssh_key
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
 
@@ -91,7 +87,7 @@ jobs:
         # Configure the ~./bash_profile and deploy.sh file on the Vagrantfile
         run: >
           ssh $SSH_USER@$SSH_HOST
-          -o StrictHostKeyChecking=no
+          -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no
           '/minitwit/deploy.sh'
         env:
           SSH_USER: ${{ secrets.SSH_USER }}

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -77,9 +77,13 @@ jobs:
 
       - name: Configure SSH
         run: |
-          mkdir -p ~/.ssh/
-          echo "$SSH_KEY" | base64 -d > ~/.ssh/do_ssh_key
-          chmod 400 ~/.ssh/do_ssh_key
+          command -v ssh-agent >/dev/null || ( apt-get update -y && apt-get install openssh-client -y )
+          eval $(ssh-agent -s)
+          echo "$SSH_KEY" | tr -d '\r' | ssh-add -
+          mkdir -p ~/.ssh
+          touch ~/.ssh/config
+          touch ~/.ssh/known_hosts
+          chmod -R 400 ~/.ssh
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}
 
@@ -87,7 +91,7 @@ jobs:
         # Configure the ~./bash_profile and deploy.sh file on the Vagrantfile
         run: >
           ssh $SSH_USER@$SSH_HOST
-          -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no
+          -o StrictHostKeyChecking=no
           '/minitwit/deploy.sh'
         env:
           SSH_USER: ${{ secrets.SSH_USER }}

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -6,8 +6,6 @@ on:
     # Run workflow every time something is pushed to the main branch
     branches:
       - main
-      - master
-      - cicd-pipeline
   # allow manual triggers for now too
   workflow_dispatch:
     manual: true

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -1,0 +1,93 @@
+---
+name: Continuous Deployment
+
+on:
+  push:
+    # Run workflow every time something is pushed to the main branch
+    branches:
+      - main
+      - master
+  # allow manual triggers for now too
+  workflow_dispatch:
+    manual: true
+
+# Remember to set the following secrets in your repository's settings:
+# https://github.com/your_username/itu-minitwit-ci/settings/secrets/actions
+# DOCKER_USERNAME
+# DOCKER_PASSWORD
+# SSH_USER
+# SSH_KEY
+# SSH_HOST
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push minitwit
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/minitwit:latest
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwit:webbuildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwit:webbuildcache,mode=max
+
+    #  - name: Build and push mysqlimage
+    #    uses: docker/build-push-action@v2
+    #    with:
+    #      context: .
+    #      file: ./Dockerfile-mysql
+    #      push: true
+    #      tags: ${{ secrets.DOCKER_USERNAME }}/mysqlimage:latest
+    #      cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/mysqlimage:mysqlbuildcache
+    #      cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/mysqlimage:mysqlbuildcache,mode=max
+
+      # - name: Build and push flagtoolimage
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     context: .
+      #     file: ./Dockerfile-flagtool
+      #     push: true
+      #     tags: ${{ secrets.DOCKER_USERNAME }}/flagtoolimage:latest
+      #     cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/flagtoolimage:flagtoolbuildcache
+      #     cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/flagtoolimage:flagtoolbuildcache,mode=max
+
+      # - name: Test minitwit
+      #   run: |
+      #     docker build -t $DOCKER_USERNAME/minitwittestimage -f Dockerfile-minitwit-tests .
+      #     yes 2>/dev/null | docker-compose up -d
+      #     docker run --rm --network=itu-minitwit-network $DOCKER_USERNAME/minitwittestimage
+      #   env:
+      #     DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_KEY" > ~/.ssh/do_ssh_key
+          chmod 600 ~/.ssh/do_ssh_key
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+
+      - name: Deploy to server
+        # Configure the ~./bash_profile and deploy.sh file on the Vagrantfile
+        run: >
+          ssh $SSH_USER@$SSH_HOST
+          -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no
+          '/minitwit/deploy.sh'
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -77,10 +77,8 @@ jobs:
 
       - name: Configure SSH
         run: |
-          sudo apt install -y dos2unix
           mkdir -p ~/.ssh/
-          echo "$SSH_KEY" > ~/.ssh/do_ssh_key
-          dos2unix ~/.ssh/do_ssh_key
+          echo "$SSH_KEY" | base64 -d > ~/.ssh/do_ssh_key
           chmod 400 ~/.ssh/do_ssh_key
         env:
           SSH_KEY: ${{ secrets.SSH_KEY }}

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main
       - master
+      - cicd-pipeline
   # allow manual triggers for now too
   workflow_dispatch:
     manual: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ log/*
 db/*.db*
 latest_processed_sim_action_id.txt
 .vagrant
+./remote_files/minitwit.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ARG APP_ENV=production
 ENV APP_ENV=$APP_ENV
 ENV PORT=$PORT
 
-RUN mkdir -p /app
-WORKDIR /app
+RUN mkdir -p /minitwit
+WORKDIR /minitwit
 
 COPY Gemfile ./
 COPY Gemfile.lock ./

--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ The Vagrantfile syncs the local repository to the VM so be sure to have a databa
 The API will be available at http://165.227.245.161:5001
 
 The interface will be available at http://165.227.245.161:5000
+
+#### Github Actions
+
+On any commits to the main branch will trigger a workflow that causes the following steps to happen:
+1. Builds the Docker image and pushes it to Docker Hub at `aguldborg/minitwit`
+2. SSH's into the Vagrant virtual machine which has been set up in [VM Provisioning & deployment](#vm-provisioning--deployment)
+3. From the virtual machine, the `deploy.sh` script is run to built and run the containers by pulling them from Docker Hub

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,6 +47,8 @@ Vagrant.configure("2") do |config|
 
       cd /minitwit
 
+      chmod +x ./deploy.sh
+
       echo 'Creating database directories'
 
       mkdir -p /db

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,10 @@ SSH_KEY_NAME = ENV["SSH_KEY_NAME"]
 Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
   config.ssh.private_key_path = PRIVATE_KEY_PATH
-  config.vm.synced_folder ".", "/app", type: "rsync"
+  config.vm.synced_folder "./remote_files", "/minitwit", type: "rsync"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+
 
   # mount synced folder to vm
   config.vm.define "droplet1" do |droplet1|
@@ -36,31 +39,19 @@ Vagrant.configure("2") do |config|
         "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
         $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
         sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-      sudo apt-get update 
+      sudo apt-get update
 
       sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
       echo 'Finished installing Docker'
 
-      cd /app
+      cd /minitwit
 
       echo 'Creating database directories'
 
       mkdir -p /db
-      mkdir -p /db/api
-      mkdir -p /db/interface
 
-      cp db/minitwit.db /db/api/.
-      cp db/minitwit.db /db/interface/.
-
-      # Build Docker image and run container
-
-      echo 'Building Docker image'
-
-      docker build . -t minitwit
-
-      docker run --name interface -d -v /db/interface:/db -e DATABASE_PATH='/db/minitwit.db' -p 5000:5000 minitwit '/app/interface.sh'
-      docker run --name simapi -d -v /db/api:/db -e PORT=5001 --expose 5001 -e DATABASE_PATH='/db/minitwit.db' -p 5001:5001 minitwit '/app/api.sh'
+      cp ./minitwit.db /db/.
     SHELL
   end
 end

--- a/api.sh
+++ b/api.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-bundle exec ruby simapi/sim_api.rb

--- a/interface.sh
+++ b/interface.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-bundle exec ruby myapp.rb

--- a/notes/Lecture4.md
+++ b/notes/Lecture4.md
@@ -1,0 +1,20 @@
+# Noter 23-02-2024
+
+* 14:03 - Giver adgang til Digital Ocean til gruppemedlemmer, sætter Docker Hub op og sætter diverse repository secrets op
+* 14:30 - Vi bruger Helge's yml workflow fil og tilpasser til vores setup. Vi opdaterer vores Vagrantfile til kun at synce `./remote_files`
+* 14:50 - Vi diskuterer, hvordan vi bedst får en database ind på Digital Ocean. Vi aftaler, at vi sætter den ind i `./remote_files` så den bliver synced ind ved `vagrant up` kommandoen. Det har den effekt, at vores database ikke bliver gemt hvis vi genstarter vores VM på digital ocean (kører `vagrant up` på ny). Det vil dog lade os komme med releases og deploye selve kodebasen i Docker-containers uden behovet for at slette vores data. Vi snakker dog om muligheden for på sigt at gøre brug af at mounte volumes på vores VM frem for kun på vores Docker-containers. Det er et tilsvarende koncept som at mounte volumes på Docker Containers: https://docs.digitalocean.com/products/volumes/how-to/mount/ - Vi vurderer dog, at det er bedre at starte med den første løsning og så klare den her refactor når vi har tiden til det.
+* 15:55 - Vi fjerner den del af vores Vagrantfile, der bygger og kører vores Docker-container. Det sker nu i stedet i Github Actions workflowet når der pushes til main.
+* 16:03 - Vi vurderer, at interfacet ikke vil blive brugt særligt ofte, men at det kan hjælpe os med at se fejl i simulator-API'et hvis de to bruger samme database. Derfor ændrer vi fra at køre hver deres database til nu at bruge den samme.
+* 16:32 - Vi bruger Helge's `docker-compose.yml` som inspiration til at lave vores eget, så vi nemt kan køre vores Docker-image på en container på vores virtual machine. Denne docker compose fil bliver brugt af vores `deploy.sh`, som er sidste step som vores Github Actions kører når den er SSH'et ind på vores VM.
+* 16:59 - Vi forsøger at køre Github Actions workflowet ved at tilføje pattern matching på den branch, den bliver udviklet på (`cicd-pipeline`). Den fejler på steppet hvor den skal SSH ind på vores VM med en fejlbesked: 
+```
+Warning: Permanently added '***' (ED25519) to the list of known hosts.
+Load key "/home/runner/.ssh/do_ssh_key": error in libcrypto
+***@***: Permission denied (publickey).
+```
+* 17:13 - Vi finder ud af, at der er problemer med at SSH ind via `vagrant ssh`. Derfor forsøger vi at lave et nyt sæt SSH-keys og bruge disse i stedet, og konfigurerer dem på både Github Actions workflowet og Digital Ocean. Dette giver os adgang til kommandoen `vagrant ssh` men fejler stadig på Github Actions workflowet.
+* 17:40 - Google viser nogle indikationer på, at det kan have noget med line-endings at gøre. SSH keysne er blevet genereret på en Windows maskine, og vi mistænker at fejlen er opstået på baggrund af CR/LF line-endings på Windows maskiner. Vi sidder dog uden andre laptops at teste med, og kan derfor ikke teste, om vi kan fixe problemet ved at lave SSH keys på et andet miljø.
+* 18:05 - Vi forsøger at lave `ssh-keygen` på Windows Subsystem for Linux med Ubuntu 22.04.3 uden held.
+
+# Noter 24-02-2024
+* 14:15 - Forsøger igen med `rsa`-type SSH-key, ligesom givet i CI-guiden fra Helge uden held. Det samme gælder, ved forsøg på at tilføje newline ved slutningen af SSH private key på Github, inspireret af denne kommentar: https://github.com/openssl/openssl/issues/19487#issuecomment-1565402253

--- a/remote_files/deploy.sh
+++ b/remote_files/deploy.sh
@@ -1,0 +1,6 @@
+source ~/.bash_profile
+
+cd /minitwit
+
+docker compose -f docker-compose.yml pull
+docker compose -f docker-compose.yml up -d

--- a/remote_files/deploy.sh
+++ b/remote_files/deploy.sh
@@ -1,5 +1,3 @@
-source ~/.bash_profile
-
 cd /minitwit
 
 docker compose -f docker-compose.yml pull

--- a/remote_files/docker-compose.yml
+++ b/remote_files/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.3"
+
+networks:
+  main:
+
+services:
+
+  minitwitimage:
+    image: ${DOCKER_USERNAME}/minitwit
+    entrypoint: /minitwit/interface.sh
+    container_name: interface
+    environment:
+      - DATABASE_PATH="/db/minitwit.db"
+      - PORT=5000
+    volumes:
+      - /db:/db
+    networks:
+      - main
+    ports:
+        - "5000:5000"
+
+  minitwitsimapiimage:
+    image: ${DOCKER_USERNAME}/minitwit
+    entrypoint: /minitwit/api.sh
+    container_name: simapi
+    environment:
+      - DATABASE_PATH="/db/minitwit.db"
+      - PORT=5001
+    volumes:
+      - /db:/db
+    networks:
+      - main
+    expose:
+      - "5001"
+    ports:
+        - "5001:5001"

--- a/remote_files/docker-compose.yml
+++ b/remote_files/docker-compose.yml
@@ -7,10 +7,10 @@ services:
 
   minitwitimage:
     image: aguldborg/minitwit
-    entrypoint: /minitwit/interface.sh
+    command: bundle exec ruby myapp.rb
     container_name: interface
     environment:
-      - DATABASE_PATH="/db/minitwit.db"
+      - DATABASE_PATH=/db/minitwit.db
       - PORT=5000
     volumes:
       - /db:/db
@@ -21,10 +21,10 @@ services:
 
   minitwitsimapiimage:
     image: aguldborg/minitwit
-    entrypoint: /minitwit/api.sh
+    command: bundle exec ruby simapi/sim_api.rb
     container_name: simapi
     environment:
-      - DATABASE_PATH="/db/minitwit.db"
+      - DATABASE_PATH=/db/minitwit.db
       - PORT=5001
     volumes:
       - /db:/db

--- a/remote_files/docker-compose.yml
+++ b/remote_files/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 services:
 
   minitwitimage:
-    image: ${DOCKER_USERNAME}/minitwit
+    image: aguldborg/minitwit
     entrypoint: /minitwit/interface.sh
     container_name: interface
     environment:
@@ -20,7 +20,7 @@ services:
         - "5000:5000"
 
   minitwitsimapiimage:
-    image: ${DOCKER_USERNAME}/minitwit
+    image: aguldborg/minitwit
     entrypoint: /minitwit/api.sh
     container_name: simapi
     environment:


### PR DESCRIPTION
@duckth pays a beer if this does not work

Add the database in `./remote_files/minitwit.db` and run `vagrant up` to start the virtual machine. (Should only be done when killing and restarting the VM on digital ocean)

With this, any commits to main will cause the workflow to start which builds a Docker image to Docker Hub on `aguldborg/minitwit` and then through SSH access to the digital ocean VM pulls and runs the docker image on the virtual machine and mounts the database.