### PR TITLE
Statuscode 404 when user not found

### DIFF
--- a/myapp.rb
+++ b/myapp.rb
@@ -159,6 +159,9 @@ get '/:username/follow' do
   return status 401 unless logged_in?
 
   whom = User.find_by_username(params[:username])
+
+  return status 404 if whom.nil?
+
   current_user.following << whom
   flash[:success] = "You are now following &#34;#{params[:username]}&#34;"
   redirect("/#{params[:username]}")
@@ -168,6 +171,9 @@ get '/:username/unfollow' do
   return status 401 unless logged_in?
 
   whom = User.find_by_username(params[:username])
+
+  return status 404 if whom.nil?
+
   current_user.following.delete(whom)
   flash[:success] = "You are no longer following &#34;#{params[:username]}&#34;"
   redirect("/#{params[:username]}")

--- a/simapi/sim_api.rb
+++ b/simapi/sim_api.rb
@@ -146,7 +146,7 @@ end
 
 get '/fllws/:username' do |username|
   user = User.find_by_username(username)
-  return [400, 'User not found'] if user.nil?
+  return [404, 'User not found'] if user.nil?
   return [400, 'no is required'] if params[:no].nil?
   count = params[:no].to_i
 
@@ -160,7 +160,7 @@ end
 
 post '/fllws/:username' do |username|
   user = User.find_by_username(username)
-  return [400, 'User not found'] if user.nil?
+  return [404, 'User not found'] if user.nil?
 
   request_data = JSON.parse(request.body.read, symbolize_names: true)
   if request_data.key?(:follow)


### PR DESCRIPTION
Fixes #26 

endpoint /fllws (api) and /follows (main app) gives 404 instead of 400 when it is not possible to find the given user.