### PR TITLE
Set statuscode to 204 endpoints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,5 @@ test_api:
 	APP_ENV=test nohup bundle exec ruby ./simapi/sim_api.rb > ./log/test.log 2>&1 &
 	sleep 2
 	- pytest minitwit_sim_api_test.py -vvv
-	pkill -f itu-minitwit
+	pkill -f minitwit
 	rm ./db/minitwit_test.*

--- a/simapi/sim_api.rb
+++ b/simapi/sim_api.rb
@@ -168,12 +168,12 @@ post '/fllws/:username' do |username|
     return [400, 'User to follow not found'] if to_follow.nil?
 
     user.following.append(to_follow)
-    status 200
+    status 204
   elsif request_data.key?(:unfollow)
     to_unfollow = User.find_by_username(request_data[:unfollow])
     return [400, 'User to unfollow not found'] if to_unfollow.nil?
 
     user.following.delete(to_unfollow)
-    status 200
+    status 204
   end
 end

--- a/simapi/sim_api.rb
+++ b/simapi/sim_api.rb
@@ -136,8 +136,8 @@ post '/msgs/:username' do |username|
   )
 
   if message
-    status 201
-    body message.to_json
+    status 204
+    body ''
   else
     status 400
     body 'Something went wrong'

--- a/simapi/sim_api.rb
+++ b/simapi/sim_api.rb
@@ -137,7 +137,6 @@ post '/msgs/:username' do |username|
 
   if message
     status 204
-    body ''
   else
     status 400
     body 'Something went wrong'


### PR DESCRIPTION
http://206.81.24.116/status.html shows, that we have errors on POST '/msgs/:username' and the `fllws` endpoints. 

Looking at the API specs in https://github.com/itu-devops/lecture_notes/blob/master/sessions/session_03/API_Spec/minitwit_sim_api.py we found that it expects statuscode 204 and not 201.