### PR TITLE
Fix non-idempotent GitHub Actions

### DIFF
--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Run minitwit
         run: |
           docker compose -f docker-compose-tests.yaml build
-          yes 2>/dev/null | docker compose -f docker-compose-tests.yaml up
+          # https://stackoverflow.com/questions/40907954/terminate-docker-compose-when-test-container-finishes
+          yes 2>/dev/null | docker compose -f docker-compose-tests.yaml up --abort-on-container-exit --exit-code-from test-runner
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -41,9 +41,8 @@ jobs:
 
       - name: Run minitwit
         run: |
-          yes 2>/dev/null | docker compose -f docker-compose-tests.yaml up -d
-          docker build -t $DOCKER_USERNAME/minitwittestimage -f Dockerfile-test .
-          docker run --rm --network=itu-minitwit-network -e MINITWIT_BASE_URL="http://minitwit:5000" $DOCKER_USERNAME/minitwittestimage
+          docker compose -f docker-compose-tests.yaml build
+          yes 2>/dev/null | docker compose -f docker-compose-tests.yaml up
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
 

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -46,7 +46,7 @@ services:
         bundle exec rake db:migrate
         bundle exec ruby myapp.rb
     healthcheck:
-      test: ["CMD", "curl --fail http://0.0.0.0:5000 || exit 1"]
+      test: ["CMD", "curl --fail http://minitwit:5000 || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -46,10 +46,11 @@ services:
         bundle exec rake db:migrate
         bundle exec ruby myapp.rb
     healthcheck:
-      test: ["CMD", "curl --fail http://localhost:5000"]
+      test: ["CMD", "curl --fail http://localhost:5000 || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 5
+      start_period: 30s
 
   test-runner:
     build:

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -45,3 +45,20 @@ services:
         bundle exec rake db:create
         bundle exec rake db:migrate
         bundle exec ruby myapp.rb
+    healthcheck:
+      test: ["CMD", "curl --fail http://localhost:5000"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  test-runner:
+    build:
+      context: .
+      dockerfile: Dockerfile-test
+    container_name: test-runner
+    networks:
+      - main
+    depends_on:
+      - minitwit
+    environment:
+      - MINITWIT_BASE_URL="http://minitwit:5000"

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -46,11 +46,10 @@ services:
         bundle exec rake db:migrate
         bundle exec ruby myapp.rb
     healthcheck:
-      test: ["CMD", "curl --fail http://minitwit:5000 || exit 1"]
+      test: ["CMD", "curl", "-f", "http://minitwit:5000/public"]
       interval: 5s
       timeout: 5s
       retries: 5
-      start_period: 30s
 
   test-runner:
     build:
@@ -63,4 +62,4 @@ services:
       minitwit:
         condition: service_healthy
     environment:
-      - MINITWIT_BASE_URL="http://minitwit:5000"
+      - MINITWIT_BASE_URL=http://minitwit:5000

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -46,7 +46,7 @@ services:
         bundle exec rake db:migrate
         bundle exec ruby myapp.rb
     healthcheck:
-      test: ["CMD", "curl --fail http://localhost:5000 || exit 1"]
+      test: ["CMD", "curl --fail http://0.0.0.0:5000 || exit 1"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -59,6 +59,7 @@ services:
     networks:
       - main
     depends_on:
-      - minitwit
+      minitwit:
+        condition: service_healthy
     environment:
       - MINITWIT_BASE_URL="http://minitwit:5000"

--- a/refactored_minitwit_tests.py
+++ b/refactored_minitwit_tests.py
@@ -60,6 +60,7 @@ def add_message(http_session, text):
 # testing functions
 
 def test_register():
+    exit(1)
     """Make sure registering works"""
     r = register('user1', 'default')
     assert 'You were successfully registered ' \

--- a/refactored_minitwit_tests.py
+++ b/refactored_minitwit_tests.py
@@ -60,7 +60,6 @@ def add_message(http_session, text):
 # testing functions
 
 def test_register():
-    exit(1)
     """Make sure registering works"""
     r = register('user1', 'default')
     assert 'You were successfully registered ' \


### PR DESCRIPTION
Fixes #30 

Current status is [this workflow](https://github.com/git-gurus-itu-devops/itu-minitwit/actions/runs/8196170989/job/22415851816)

After database and minitwit seems to be running correctly, it fails with error message:
> dependency failed to start: container minitwit is unhealthy

This PR should fix the fact that our tests sometimes fails if they run before the application is running

I have attempted pointing the health-check to localhost, 0.0.0.0 and minitwit - all with port 5000. Inspiration for healthcheck is [this](https://helpcenter.gamewarden.io/client-guidance/docker-healthcheck/#example-1-add-healthcheck-command-in-dockerfile-using-curl) and [this article](https://www.paulsblog.dev/how-to-successfully-implement-a-healthcheck-in-docker-compose/).

Any help is very much appreciated!