### PR TITLE
Add GH public keys as authorized SSH keys

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,6 @@ SSH_KEY_NAME = ENV["SSH_KEY_NAME"]
 Vagrant.configure("2") do |config|
   config.ssh.insert_key = false
   config.ssh.private_key_path = PRIVATE_KEY_PATH
-  config.ssh.username = 'gha'
   config.vm.synced_folder "./remote_files", "/minitwit", type: "rsync"
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
@@ -43,6 +42,12 @@ Vagrant.configure("2") do |config|
       sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
       echo 'Finished installing Docker'
+
+      sudo ssh-import-id-gh duckth
+      sudo ssh-import-id-gh A-Guldborg
+      sudo ssh-import-id-gh fredpetersen
+      sudo ssh-import-id-gh silkeholmebonnen
+      sudo ssh-import-id-gh MadsRoager
 
       cd /minitwit
 


### PR DESCRIPTION
Clicking your avatar => Settings => SSH and GPG keys then you add your keys as seen here. With this pull request, our SSH public keys will automatically be added to the droplet on provision, meaning you can ssh into the droplet easily.

Create a key pair with a command such as `ssh-keygen -f ~/.ssh/do_ssh_key -t rsa -b 4096 -m "PEM"` and upload the *PUBLIC* key to GitHub.

![image](https://github.com/git-gurus-itu-devops/itu-minitwit/assets/95026056/bc19cb52-0943-4452-ae7a-a9f7070ca71c)


NB: Also removes GHA user as the ssh access user for vagrant up as this was causing issues. Now it defaults to root.