### PR TITLE
Use ActiveRecord validations for user creation

### DIFF
--- a/models/user.rb
+++ b/models/user.rb
@@ -19,6 +19,10 @@ class User < ActiveRecord::Base
 
   has_secure_password
 
+  validates :username, presence: true, uniqueness: true
+  validates :password, :password_confirmation, presence: true
+  validates :email, presence: true, uniqueness: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+
   def follows?(other_user)
     following.include?(other_user)
   end

--- a/myapp.rb
+++ b/myapp.rb
@@ -55,10 +55,6 @@ configure :test do
 end
 
 helpers do
-  def nil_or_empty?(string)
-    string.nil? || string.empty?
-  end
-
   def logged_in?
     !!session[:user_id]
   end
@@ -98,28 +94,19 @@ get '/register' do
 end
 
 post '/register' do
-  if nil_or_empty?(params[:username])
-    error = 'You have to enter a username'
-  elsif nil_or_empty?(params[:email]) || params[:email] !~ /@/
-    error = 'You have to enter a valid email address'
-  elsif nil_or_empty?(params[:password])
-    error = 'You have to enter a password'
-  elsif params[:password] != params[:password2]
-    error = 'The two passwords do not match'
-  elsif User.find_by_username(params[:username])
-    error = 'The username is already taken'
-  elsif User.create(
+  u = User.new(
     username: params[:username],
     email: params[:email],
     password: params[:password],
     password_confirmation: params[:password2]
   )
+  if u.save
     flash[:success] = 'You were successfully registered and can login now'
     redirect('/login')
   else
-    error = 'Something went wrong'
+    errors = u.errors.map(&:full_message).join(', ')
+    flash[:error] = errors
   end
-  flash[:error] = error
   redirect('/register')
 end
 

--- a/myapp.rb
+++ b/myapp.rb
@@ -94,17 +94,17 @@ get '/register' do
 end
 
 post '/register' do
-  u = User.new(
+  user = User.new(
     username: params[:username],
     email: params[:email],
     password: params[:password],
     password_confirmation: params[:password2]
   )
-  if u.save
+  if user.save
     flash[:success] = 'You were successfully registered and can login now'
     redirect('/login')
   else
-    errors = u.errors.map(&:full_message).join(', ')
+    errors = user.errors.map(&:full_message).join(', ')
     flash[:error] = errors
   end
   redirect('/register')

--- a/notes/Lecture8.md
+++ b/notes/Lecture8.md
@@ -1,0 +1,15 @@
+# Lecture 8
+
+## NewRelic Logging
+
+15-03-2024
+
+* Installeret new relic infrastructure og logging agent på VM "droplet1"
+* Tilføjet /etc/docker/daemon.log med konfiguration der får Docker til at skrive logs til syslog. Derefter genstartet via. systemctl
+* Rettet /etc/newrelic-infra/logging.d/logging.yml så Docker Container logs ikke bliver samlet op, da de nu kommer fra syslog
+
+## Register refactoring
+
+15-03-2024
+
+* Register endpoint er refactored til at bruge ActiveRecord validations i stedet for manuelle validations

--- a/refactored_minitwit_tests.py
+++ b/refactored_minitwit_tests.py
@@ -65,15 +65,15 @@ def test_register():
     assert 'You were successfully registered ' \
            'and can login now' in r.text
     r = register('user1', 'default')
-    assert 'The username is already taken' in r.text
+    assert "Username has already been taken" in r.text
     r = register('', 'default')
-    assert 'You have to enter a username' in r.text
+    assert "Username can't be blank" in r.text
     r = register('meh', '')
-    assert 'You have to enter a password' in r.text
+    assert "Password can't be blank" in r.text
     r = register('meh', 'x', 'y')
-    assert 'The two passwords do not match' in r.text
+    assert "Password confirmation doesn't match Password" in r.text
     r = register('meh', 'foo', email='broken')
-    assert 'You have to enter a valid email address' in r.text
+    assert "Email is invalid" in r.text
 
 def test_login_logout():
     """Make sure logging in and logging out works"""


### PR DESCRIPTION
This PR changes the register endpoints to use the native ActiveRecord validation methods instead of the "validate_create_user" endpoint. The messages have been changed in the tests to reflect the messages ActiveRecord generates. Shouldn't affect the simulator as it doesn't actually care about the message.