### PR TITLE
Adds staging env

### DIFF
--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -75,7 +75,7 @@ jobs:
         run: >
           ssh $SSH_USER@$SSH_HOST
           -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no
-          '/minitwit/deploy.sh ${{ secrets.DATABASE_URL }} ${{ secrets.NR_LICENSE_KEY }}'
+          '/minitwit/deploy.sh ${{ secrets.DATABASE_URL }} ${{ secrets.NR_LICENSE_KEY }} latest'
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}

--- a/.github/workflows/continous-deployment.yml
+++ b/.github/workflows/continous-deployment.yml
@@ -8,7 +8,6 @@ on:
       - main
   # allow manual triggers for now too
   workflow_dispatch:
-    manual: true
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,5 +1,5 @@
 ---
-name: Continuous Deployment
+name: Deploy to staging
 
 on: 
   workflow_dispatch:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -2,10 +2,6 @@
 name: Continuous Deployment
 
 on: 
-  push:
-    branches:
-      - feature/staging-env
-  
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,9 +3,6 @@ name: Deploy to staging
 
 on: 
   workflow_dispatch:
-  push:
-    branches:
-      - feature/staging-env
 
 jobs:
   build:
@@ -37,14 +34,6 @@ jobs:
           tags: ${{ secrets.DOCKER_USERNAME }}/minitwit:${{ github.sha }}
           cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwit:webbuildcache
           cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwit:webbuildcache,mode=max
-
-      - name: Build and push minitwit-api
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ./simapi/Dockerfile-api
-          push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/minitwit-api:${{ github.sha }}
 
       - name: Configure SSH
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -51,7 +51,6 @@ jobs:
 
       - name: Deploy to server
         # Configure the ~./bash_profile and deploy.sh file on the Vagrantfile
-        if: ${{ github.ref == 'refs/heads/main' }} # Deploy only on main
         run: >
           ssh $SSH_USER@$SSH_HOST
           -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -31,7 +31,6 @@ jobs:
           build-args: |
             RACK_ENV=staging
             APP_ENV=staging
-            MINITWIT_VERSION=${{ github.sha }}
           context: .
           file: ./Dockerfile
           push: true
@@ -60,7 +59,7 @@ jobs:
         run: >
           ssh $SSH_USER@$SSH_HOST
           -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no
-          '/minitwit/deploy.sh ${{ secrets.DATABASE_URL }} ${{ secrets.NR_LICENSE_KEY }}'
+          '/minitwit/deploy.sh ${{ secrets.DATABASE_URL }} ${{ secrets.NR_LICENSE_KEY }} ${{ github.sha }}'
         env:
           SSH_USER: ${{ secrets.SSH_USER }}
           SSH_HOST: ${{ secrets.SSH_HOST }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: staging
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,6 +3,9 @@ name: Deploy to staging
 
 on: 
   workflow_dispatch:
+  push:
+    branches:
+      - feature/staging-env
 
 jobs:
   build:
@@ -28,6 +31,7 @@ jobs:
           build-args: |
             RACK_ENV=staging
             APP_ENV=staging
+            MINITWIT_VERSION=${{ github.sha }}
           context: .
           file: ./Dockerfile
           push: true

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,7 +1,12 @@
 ---
 name: Continuous Deployment
 
-on: workflow_dispatch
+on: 
+  push:
+    branches:
+      - feature/staging-env
+  
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,61 @@
+---
+name: Continuous Deployment
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push minitwit
+        uses: docker/build-push-action@v5
+        with:
+          build-args: |
+            RACK_ENV=staging
+            APP_ENV=staging
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/minitwit:${{ github.sha }}
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwit:webbuildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwit:webbuildcache,mode=max
+
+      - name: Build and push minitwit-api
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./simapi/Dockerfile-api
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/minitwit-api:${{ github.sha }}
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_KEY" > ~/.ssh/do_ssh_key
+          chmod 600 ~/.ssh/do_ssh_key
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY }}
+
+      - name: Deploy to server
+        # Configure the ~./bash_profile and deploy.sh file on the Vagrantfile
+        if: ${{ github.ref == 'refs/heads/main' }} # Deploy only on main
+        run: >
+          ssh $SSH_USER@$SSH_HOST
+          -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no
+          '/minitwit/deploy.sh ${{ secrets.DATABASE_URL }} ${{ secrets.NR_LICENSE_KEY }}'
+        env:
+          SSH_USER: ${{ secrets.SSH_USER }}
+          SSH_HOST: ${{ secrets.SSH_HOST }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,9 @@ RUN apt update && apt upgrade -y
 ARG PORT=5000
 ARG APP_ENV=production
 ARG RACK_ENV=production
-ARG MINITWIT_VERSION=latest
 ENV APP_ENV=$APP_ENV
 ENV RACK_ENV=$RACK_ENV
 ENV PORT=$PORT
-ENV MINITWIT_VERSION=$MINITWIT_VERSION
 
 RUN mkdir -p /minitwit
 WORKDIR /minitwit

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ RUN apt update && apt upgrade -y
 ARG PORT=5000
 ARG APP_ENV=production
 ARG RACK_ENV=production
+ARG MINITWIT_VERSION=latest
 ENV APP_ENV=$APP_ENV
 ENV RACK_ENV=$RACK_ENV
 ENV PORT=$PORT
+ENV MINITWIT_VERSION=$MINITWIT_VERSION
 
 RUN mkdir -p /minitwit
 WORKDIR /minitwit

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -54,4 +54,43 @@ Vagrant.configure("2") do |config|
       chmod +x ./deploy.sh
     SHELL
   end
+
+  config.vm.define "staging" do |staging|
+    staging.vm.provider :digital_ocean do |provider, override|
+      override.vm.box = 'digital_ocean'
+      override.vm.box_url = DO_BOX_URL
+      override.nfs.functional = false
+      provider.ssh_key_name = SSH_KEY_NAME
+      provider.token = TOKEN
+      provider.image = 'ubuntu-22-04-x64'
+      provider.region = 'fra1'
+      provider.size = 's-1vcpu-1gb'
+    end
+
+    staging.vm.provision "shell", privileged: false, inline: <<-SHELL
+      echo 'Installing Docker'
+
+      # Add Docker's official GPG key:
+      sudo apt-get update
+      sudo apt-get install -y ca-certificates curl
+      sudo install -m 0755 -d /etc/apt/keyrings
+      sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+      sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+      # Add the repository to Apt sources:
+      echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+        sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+      sudo apt-get update
+
+      sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+      echo 'Finished installing Docker'
+
+      cd /minitwit
+
+      chmod +x ./deploy.sh
+    SHELL
+  end
 end

--- a/myapp.rb
+++ b/myapp.rb
@@ -12,7 +12,7 @@ PR_PAGE = 30
 
 DATABASE_URL = ENV['DATABASE_URL']
 
-configure :production do
+configure :production, :staging do
   db = URI.parse(DATABASE_URL)
   set :database, {
     adapter: db.scheme,

--- a/newrelic.yml
+++ b/newrelic.yml
@@ -67,5 +67,7 @@ test:
 production:
   <<: *default_settings
 
-### This is also where we would have configuration for a staging environemnt, if we had one
+staging:
+  <<: *default_settings
+  app_name: 'MiniTwit (Staging)'
 

--- a/remote_files/deploy.sh
+++ b/remote_files/deploy.sh
@@ -3,6 +3,7 @@ cd /minitwit
 # Set by continous-deployment, pulled from GH secrets
 export DATABASE_URL=$1
 export NR_LICENSE_KEY=$2
+export MINITWIT_VERSION=$3
 
 docker compose -f docker-compose.yml pull
 docker compose -f docker-compose.yml up -d

--- a/remote_files/docker-compose.yml
+++ b/remote_files/docker-compose.yml
@@ -7,7 +7,12 @@ services:
 
   minitwitimage:
     image: aguldborg/minitwit
-    command: bundle exec ruby myapp.rb
+    command:
+      - /bin/bash
+      - -c
+      - |
+        bundle exec rake db:migrate
+        bundle exec ruby myapp.rb
     container_name: interface
     environment:
       - PORT=5000
@@ -20,7 +25,12 @@ services:
 
   minitwitsimapiimage:
     image: aguldborg/minitwit
-    command: bundle exec ruby simapi/sim_api.rb
+    command:
+      - /bin/bash
+      - -c
+      - |
+        bundle exec rake db:migrate
+        bundle exec ruby simapi/sim_api.rb
     container_name: simapi
     environment:
       - PORT=5001

--- a/remote_files/docker-compose.yml
+++ b/remote_files/docker-compose.yml
@@ -6,7 +6,7 @@ networks:
 services:
 
   minitwitimage:
-    image: aguldborg/minitwit
+    image: aguldborg/minitwit:${MINITWIT_VERSION}
     command:
       - /bin/bash
       - -c
@@ -24,7 +24,7 @@ services:
       - "5000:5000"
 
   minitwitsimapiimage:
-    image: aguldborg/minitwit
+    image: aguldborg/minitwit:${MINITWIT_VERSION}
     command:
       - /bin/bash
       - -c

--- a/simapi/sim_api.rb
+++ b/simapi/sim_api.rb
@@ -10,7 +10,7 @@ require 'newrelic_rpm'
 
 DATABASE_URL = ENV['DATABASE_URL']
 
-configure :production do
+configure :production, :staging do
   db = URI.parse(DATABASE_URL)
   set :database, {
     adapter: db.scheme,


### PR DESCRIPTION
This creates a staging environment that can be deployed through `vagrant up staging` and then deployed manually through github.

URL: 209.38.178.2

(Add port :5000 and :5001 and endpoints just like in production. Uses a separate database in the same managed database cluster but otherwise works the same)