### PR TITLE
add simulator test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ latest_processed_sim_action_id.txt
 .vagrant
 remote_files/minitwit.db
 __pycache__
+/simapi/simulator_output.txt

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,15 @@ test_api:
 	- pytest ./simapi/minitwit_sim_api_test.py -vvv
 	pkill -f minitwit
 	APP_ENV=test bundle exec rake db:drop
+
+
+test_sim_api:
+	APP_ENV=test bundle exec rake db:create
+	APP_ENV=test bundle exec rake db:migrate
+	mkdir -p log
+	APP_ENV=test nohup bundle exec ruby ./simapi/sim_api.rb > ./log/test.log 2>&1 &
+	sleep 2
+	- python ./simapi/minitwit_simulator.py "http://127.0.0.1:4567" "./simapi/minitwit_scenario.csv" true > ./simapi/simulator_output.txt
+	- pytest simapi/minitwit_simulator_test.py "./simapi/simulator_output.txt"
+	pkill -f minitwit
+	APP_ENV=test bundle exec rake db:drop

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ sudo apt update && sudo apt install libpq-dev
 Run tests with `make test`
 App cannot run while testing
 
+Run simulator tests with `make test_sim_api`
+
 ### Run Dockerfile
 
 Build the Dockerfile
@@ -43,7 +45,7 @@ The volume mount should point to the local database.
 If `<cmd>` is not supplied, will run the app
 
 
-### VM Provisioning & Deployment 
+### VM Provisioning & Deployment
 
 Virtual Machine provisioning is handled by Vagrant in DigitalOcean.
 Run provisioning with `vagrant up`

--- a/simapi/Dockerfile-api-test
+++ b/simapi/Dockerfile-api-test
@@ -2,13 +2,11 @@ FROM python:3.7-alpine
 
 RUN mkdir /minitwit-api-tests
 
-COPY ./simapi/minitwit_sim_api_test.py /minitwit-api-tests/
+COPY ./simapi/ /minitwit-api-tests/
 COPY requirements.txt /minitwit-api-tests/
 
 WORKDIR /minitwit-api-tests
 
 RUN pip install -r requirements.txt
 
-EXPOSE 5001
-
-ENTRYPOINT ["pytest", "-s", "minitwit_sim_api_test.py"]
+ENTRYPOINT pytest -s minitwit_sim_api_test.py && python ./minitwit_simulator.py "http://minitwit-api:5001" "./minitwit_scenario.csv" true > ./simulator_output.txt && pytest ./minitwit_simulator_test.py "./simulator_output.txt"

--- a/simapi/minitwit_sim_api_test.py
+++ b/simapi/minitwit_sim_api_test.py
@@ -27,8 +27,7 @@ def test_latest():
     url = f"{BASE_URL}/latest"
     response = requests.get(url, headers=HEADERS)
     assert response.ok
-    # assert response.json()["latest"] == 1337
-    assert response.json()["latest"] == 1
+    assert response.json()["latest"] == 1337
 
 
 def test_register():

--- a/simapi/minitwit_sim_api_test.py
+++ b/simapi/minitwit_sim_api_test.py
@@ -27,7 +27,8 @@ def test_latest():
     url = f"{BASE_URL}/latest"
     response = requests.get(url, headers=HEADERS)
     assert response.ok
-    assert response.json()["latest"] == 1337
+    # assert response.json()["latest"] == 1337
+    assert response.json()["latest"] == 1
 
 
 def test_register():

--- a/simapi/minitwit_simulator.py
+++ b/simapi/minitwit_simulator.py
@@ -27,7 +27,7 @@ HEADERS = {
     "Content-Type": "application/json",
     f"Authorization": f"Basic {ENCODED_CREDENTIALS}",
 }
-SHORT_NUMBER = 1000
+ACTIONS_LIMIT = 1000
 
 
 def get_actions(csv_filename, short=False):
@@ -39,7 +39,7 @@ def get_actions(csv_filename, short=False):
         # for each line in .csv
         i = 0
         for line in reader:
-            if short and i > SHORT_NUMBER:
+            if short and i > ACTIONS_LIMIT:
                 break
             i += 1
             try:

--- a/simapi/minitwit_simulator.py
+++ b/simapi/minitwit_simulator.py
@@ -30,7 +30,7 @@ HEADERS = {
 ACTIONS_LIMIT = 1000
 
 
-def get_actions(csv_filename, short=False):
+def get_actions(csv_filename, limit=False):
 
     # read scenario .csv and parse to a list of lists
     with open(csv_filename, "r", encoding="utf-8") as f:
@@ -39,7 +39,7 @@ def get_actions(csv_filename, short=False):
         # for each line in .csv
         i = 0
         for line in reader:
-            if short and i > ACTIONS_LIMIT:
+            if limit and i > ACTIONS_LIMIT:
                 break
             i += 1
             try:
@@ -105,8 +105,8 @@ def get_actions(csv_filename, short=False):
                 print(traceback.format_exc())
 
 
-def main(host, csv_filename, short=False):
-    for action, delay in get_actions(csv_filename, short):
+def main(host, csv_filename, limit=False):
+    for action, delay in get_actions(csv_filename, limit):
         try:
             # SWITCH ON TYPE
             command = action["post_type"]

--- a/simapi/minitwit_simulator.py
+++ b/simapi/minitwit_simulator.py
@@ -18,8 +18,6 @@ from datetime import datetime
 from contextlib import closing
 import sqlite3
 
-
-CSV_FILENAME = "./minitwit_scenario.csv"
 USERNAME = "simulator"
 PWD = "super_safe!"
 CREDENTIALS = ":".join([USERNAME, PWD]).encode("ascii")
@@ -29,16 +27,21 @@ HEADERS = {
     "Content-Type": "application/json",
     f"Authorization": f"Basic {ENCODED_CREDENTIALS}",
 }
+SHORT_NUMBER = 1000
 
 
-def get_actions():
+def get_actions(csv_filename, short=False):
 
     # read scenario .csv and parse to a list of lists
-    with open(CSV_FILENAME, "r", encoding="utf-8") as f:
+    with open(csv_filename, "r", encoding="utf-8") as f:
         reader = csv.reader(f, delimiter="\t", quotechar=None)
 
         # for each line in .csv
+        i = 0
         for line in reader:
+            if short and i > SHORT_NUMBER:
+                break
+            i += 1
             try:
                 # we know that the command string is always the fourth element
                 command = line[3]
@@ -102,8 +105,8 @@ def get_actions():
                 print(traceback.format_exc())
 
 
-def main(host):
-    for action, delay in get_actions():
+def main(host, csv_filename, short=False):
+    for action, delay in get_actions(csv_filename, short):
         try:
             # SWITCH ON TYPE
             command = action["post_type"]
@@ -324,5 +327,9 @@ def main(host):
 
 if __name__ == "__main__":
     host = sys.argv[1]
+    csv_filename = sys.argv[2]
 
-    main(host)
+    if len(sys.argv) > 3:
+        main(host, csv_filename, sys.argv[3])
+    else:
+        main(host, csv_filename)

--- a/simapi/minitwit_simulator_test.py
+++ b/simapi/minitwit_simulator_test.py
@@ -20,7 +20,7 @@ def test_file_line_count(log_file):
 
     # Assert that the number of lines is less than the threshold
     assert (
-        len(lines) < 1
+        len(lines) < 0
     ), f"Number of lines exceeds the threshold of {MAX_LINES_THRESHOLD}"
 
 

--- a/simapi/minitwit_simulator_test.py
+++ b/simapi/minitwit_simulator_test.py
@@ -2,11 +2,9 @@
 import pytest
 import sys
 
-# Define the maximum number of lines allowed in the file
 MAX_LINES_THRESHOLD = 10
 
 
-# Define the fixture to open the file
 @pytest.fixture
 def log_file():
     file_name = sys.argv[2]
@@ -15,46 +13,36 @@ def log_file():
 
 
 def test_file_line_count(log_file):
-    # Read all lines from the file
     lines = log_file.readlines()
 
-    # Assert that the number of lines is less than the threshold
     assert (
         len(lines) < MAX_LINES_THRESHOLD
     ), f"Number of lines exceeds the threshold of {MAX_LINES_THRESHOLD}"
 
 
 def test_no_tweet_errors(log_file):
-    # Read all lines from the file
     lines = log_file.readlines()
 
-    # Check each line for the presence of "tweet"
     for line in lines:
         assert "tweet" not in line, "Found a line containing 'tweet'"
 
 
 def test_no_register_errors(log_file):
-    # Read all lines from the file
     lines = log_file.readlines()
 
-    # Check each line for the presence of "tweet"
     for line in lines:
         assert "register" not in line, "Found a line containing 'register'"
 
 
 def test_no_follow_errors(log_file):
-    # Read all lines from the file
     lines = log_file.readlines()
 
-    # Check each line for the presence of "tweet"
     for line in lines:
         assert "follow" not in line, "Found a line containing 'follow'"
 
 
 def test_no_unfollow_errors(log_file):
-    # Read all lines from the file
     lines = log_file.readlines()
 
-    # Check each line for the presence of "tweet"
     for line in lines:
         assert "unfollow" not in line, "Found a line containing 'unfollow'"

--- a/simapi/minitwit_simulator_test.py
+++ b/simapi/minitwit_simulator_test.py
@@ -20,7 +20,7 @@ def test_file_line_count(log_file):
 
     # Assert that the number of lines is less than the threshold
     assert (
-        len(lines) < MAX_LINES_THRESHOLD
+        len(lines) < 1
     ), f"Number of lines exceeds the threshold of {MAX_LINES_THRESHOLD}"
 
 

--- a/simapi/minitwit_simulator_test.py
+++ b/simapi/minitwit_simulator_test.py
@@ -1,0 +1,60 @@
+# test_file_lines.py
+import pytest
+import sys
+
+# Define the maximum number of lines allowed in the file
+MAX_LINES_THRESHOLD = 10
+
+
+# Define the fixture to open the file
+@pytest.fixture
+def log_file():
+    file_name = sys.argv[2]
+    with open(file_name) as file:
+        yield file
+
+
+def test_file_line_count(log_file):
+    # Read all lines from the file
+    lines = log_file.readlines()
+
+    # Assert that the number of lines is less than the threshold
+    assert (
+        len(lines) < MAX_LINES_THRESHOLD
+    ), f"Number of lines exceeds the threshold of {MAX_LINES_THRESHOLD}"
+
+
+def test_no_tweet_errors(log_file):
+    # Read all lines from the file
+    lines = log_file.readlines()
+
+    # Check each line for the presence of "tweet"
+    for line in lines:
+        assert "tweet" not in line, "Found a line containing 'tweet'"
+
+
+def test_no_register_errors(log_file):
+    # Read all lines from the file
+    lines = log_file.readlines()
+
+    # Check each line for the presence of "tweet"
+    for line in lines:
+        assert "register" not in line, "Found a line containing 'register'"
+
+
+def test_no_follow_errors(log_file):
+    # Read all lines from the file
+    lines = log_file.readlines()
+
+    # Check each line for the presence of "tweet"
+    for line in lines:
+        assert "follow" not in line, "Found a line containing 'follow'"
+
+
+def test_no_unfollow_errors(log_file):
+    # Read all lines from the file
+    lines = log_file.readlines()
+
+    # Check each line for the presence of "tweet"
+    for line in lines:
+        assert "unfollow" not in line, "Found a line containing 'unfollow'"

--- a/simapi/minitwit_simulator_test.py
+++ b/simapi/minitwit_simulator_test.py
@@ -20,7 +20,7 @@ def test_file_line_count(log_file):
 
     # Assert that the number of lines is less than the threshold
     assert (
-        len(lines) < 0
+        len(lines) < MAX_LINES_THRESHOLD
     ), f"Number of lines exceeds the threshold of {MAX_LINES_THRESHOLD}"
 
 


### PR DESCRIPTION
This PR should close issue #38. 

The test makes sure that there are fewer than 10 errors in total, and checks that no errors of type `tweet`, `register`, `follow` or `unfollow`. This is to get around the fact that we usually get a few `ReadTimeout` and `ConnectionError`.  I also limited the simulator to only do a 1000 requests. I don't know if we want this or if we want to fire the 25000 requests of?