### PR TITLE
Set and get latest in db instead of file

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_09_222738) do
     t.index ["who_id", "whom_id"], name: "index_followers_on_who_id_and_whom_id"
   end
 
+  create_table "latest", force: :cascade do |t|
+    t.integer "value"
+  end
+
   create_table "messages", force: :cascade do |t|
     t.bigint "author_id"
     t.string "text", null: false

--- a/models/latest.rb
+++ b/models/latest.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Latest < ActiveRecord::Base
+  self.table_name = "latest"
+
+  class << self
+    def set(latest)
+      Latest.first.update!(value: latest)
+    end
+
+    def get
+      Latest.first.value
+    end
+  end
+end

--- a/myapp.rb
+++ b/myapp.rb
@@ -6,6 +6,7 @@ require "sinatra/flash"
 require "./models/message"
 require "./models/user"
 require "./models/follower"
+require "./models/latest"
 require "newrelic_rpm"
 
 PR_PAGE = 30

--- a/myapp.rb
+++ b/myapp.rb
@@ -3,11 +3,8 @@
 require "sinatra/activerecord"
 require "sinatra"
 require "sinatra/flash"
-require "./models/message"
-require "./models/user"
-require "./models/follower"
-require "./models/latest"
 require "newrelic_rpm"
+Dir["./models/*.rb"].each { |file| require file }
 
 PR_PAGE = 30
 

--- a/simapi/sim_api.rb
+++ b/simapi/sim_api.rb
@@ -2,12 +2,9 @@
 
 require "sinatra/activerecord"
 require "sinatra"
-require "./models/message"
-require "./models/user"
-require "./models/follower"
-require "./models/latest"
 require "json"
 require "newrelic_rpm"
+Dir["./models/*.rb"].each { |file| require file }
 
 DATABASE_URL = ENV.fetch("DATABASE_URL", nil)
 

--- a/simapi/sim_api.rb
+++ b/simapi/sim_api.rb
@@ -5,6 +5,7 @@ require "sinatra"
 require "./models/message"
 require "./models/user"
 require "./models/follower"
+require "./models/latest"
 require "json"
 require "newrelic_rpm"
 
@@ -61,8 +62,7 @@ end
 
 def update_latest(request)
   parsed_command_id = request.params["latest"].to_i || -1
-
-  File.write("./latest_processed_sim_action_id.txt", parsed_command_id.to_i, mode: "w") if parsed_command_id != -1
+  Latest.set(parsed_command_id)
 end
 
 before do
@@ -76,14 +76,7 @@ before do
 end
 
 get "/latest" do
-  begin
-    content = File.read("latest_processed_sim_action_id.txt")
-    latest_processed_command_id = content.to_i
-  rescue StandardError
-    latest_processed_command_id = -1
-  end
-
-  body({ latest: latest_processed_command_id }.to_json)
+  body({ latest: Latest.get }.to_json)
 end
 
 post "/register" do

--- a/simapi/sim_api.rb
+++ b/simapi/sim_api.rb
@@ -58,8 +58,8 @@ helpers do
 end
 
 def update_latest(request)
-  parsed_command_id = request.params["latest"].to_i || -1
-  Latest.set(parsed_command_id)
+  parsed_command_id = request.params["latest"]
+  Latest.set(parsed_command_id.to_i) if parsed_command_id.present?
 end
 
 before do


### PR DESCRIPTION
This PR will add a new table and model for handling the "Latest processed command" concept. Instead of a file, we will now save the command ID in a single-row table in the database. The model contains static methods for abstraction of the setting and getting.
In the migration file, the current value is read from the text file and inserted as the base value. I am not a gigantic fan of inserting data in the migration, but @A-Guldborg has (almost) convinced me that this is basically just schema migration (from a "text table" to a postgres table) so ehh. It works.