### PR TITLE
Add some indexes to speed up queries

### DIFF
--- a/db/migrate/20240409214346_add_index_to_followers.rb
+++ b/db/migrate/20240409214346_add_index_to_followers.rb
@@ -1,0 +1,8 @@
+class AddIndexToFollowers < ActiveRecord::Migration[7.1]
+  # https://api.rubyonrails.org/v7.1.3.2/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-add_index
+  disable_ddl_transaction!
+
+  def change
+    add_index :followers, [:who_id, :whom_id], algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240409215306_add_index_to_flagged.rb
+++ b/db/migrate/20240409215306_add_index_to_flagged.rb
@@ -1,0 +1,7 @@
+class AddIndexToFlagged < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :messages, :flagged, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20240409222738_add_index_to_created_at.rb
+++ b/db/migrate/20240409222738_add_index_to_created_at.rb
@@ -2,6 +2,6 @@ class AddIndexToCreatedAt < ActiveRecord::Migration[7.1]
   disable_ddl_transaction!
 
   def change
-    add_index :messages, :created_at, algorithm: :concurrently
+    add_index :messages, :created_at, order: :desc, algorithm: :concurrently
   end
 end

--- a/db/migrate/20240409222738_add_index_to_created_at.rb
+++ b/db/migrate/20240409222738_add_index_to_created_at.rb
@@ -1,0 +1,7 @@
+class AddIndexToCreatedAt < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :messages, :created_at, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_09_222738) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["author_id"], name: "index_messages_on_author_id"
-    t.index ["created_at"], name: "index_messages_on_created_at"
+    t.index ["created_at"], name: "index_messages_on_created_at", order: :desc
     t.index ["flagged"], name: "index_messages_on_flagged"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_01_114515) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_09_222738) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "followers", force: :cascade do |t|
     t.integer "who_id"
     t.integer "whom_id"
+    t.index ["who_id", "whom_id"], name: "index_followers_on_who_id_and_whom_id"
   end
 
   create_table "messages", force: :cascade do |t|
@@ -26,6 +27,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_01_114515) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["author_id"], name: "index_messages_on_author_id"
+    t.index ["created_at"], name: "index_messages_on_created_at"
+    t.index ["flagged"], name: "index_messages_on_flagged"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
This PR will add some indexes to our database that should MASSIVELY improve query time in some cases.
- (who_id, whom_id) on followers should improve deletion on followers, one of the queries we spend most time on currently.
- (created_at) should **drastically** improve sorting time on messages (on fx. the /public page). Tested on production-sized database and its something like a factor of 100.
- (flagged) is mostly just for good measure since we often filter on it. Since we don't really use it I don't know how much this will really improve but no reason not to